### PR TITLE
Configure dev-server script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2914,6 +2914,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "jest --passWithNoTests && webpack --config config/webpack.server.js && webpack --config config/webpack.prod.js",
     "lint": "eslint src --ext .ts,.js",
     "test": "jest",
-    "dev-server": "nodemon src/server/app.ts",
+    "dev-server": "cross-env PUBLIC_PATH=../../public nodemon src/server/app.ts",
     "dev-client": "webpack serve --config config/webpack.dev.js"
   },
   "jest": {
@@ -39,6 +39,7 @@
     "@typescript-eslint/parser": "^4.11.1",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^7.0.0",
+    "cross-env": "^7.0.3",
     "css-loader": "^5.0.1",
     "eslint": "^7.17.0",
     "eslint-config-airbnb-typescript": "^12.0.0",

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -20,7 +20,7 @@
   "rules": {
     "no-plusplus": "off",
     "no-console": "warn",
-    "max-len": ["warn", { "code": 100 }],
+    "max-len": ["warn", { "code": 120 }],
     "indent": ["warn", 2]
   }
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -5,7 +5,8 @@ import path from 'path';
 const app = express();
 const server = http.createServer(app);
 const PORT = process.env.PORT || 3000;
-const PUBLIC_PATH = path.resolve(__dirname, './public');
+const PUBLIC_PATH = process.env.PUBLIC_PATH ? path.resolve(__dirname, process.env.PUBLIC_PATH)
+  : path.resolve(__dirname, './public');
 
 app.use(express.static(PUBLIC_PATH));
 


### PR DESCRIPTION
В общем, добавил тут возможность указывать папку со статичными файлами для серверной части через переменную окружения. Потребовалось для этого доп пакет установить в дев зависимости, что бы и на винде и на маке работало. 

Ну и заодно увеличил в конфиге eslint-а максимальную длину строки кода до 120 символов, извините, я не сдержался)))