### PR TITLE
feat/refactor: add PlayerSpell class with initiative calculation

### DIFF
--- a/src/server/game/casting-spells/casting-spells.ts
+++ b/src/server/game/casting-spells/casting-spells.ts
@@ -2,11 +2,11 @@ import { Player } from '../../player';
 import { ICard } from '../../../common';
 import { CardHandler } from './type';
 
-const FASTEST_SPELL_INDEX = 1;
-const FASTEST_SPELL = 200;
+// const FASTEST_SPELL_INDEX = 1;
+// const FASTEST_SPELL = 200;
 
-const QUICK_SPELL_INDEX = 2;
-const QUICK_SPELL = 100;
+// const QUICK_SPELL_INDEX = 2;
+// const QUICK_SPELL = 100;
 
 const numberLivingPlayersForEnd = 1;
 
@@ -34,22 +34,22 @@ export class CastingSpells {
   }
 
   private calculateInitiative(): Array<Player> {
-    const orderSpells = this.players.map((player) => {
-      // не забыть обработать когда меньше трех карт с 0 инициативой через кубик
-      if (player.spellCards.length === FASTEST_SPELL_INDEX) {
-        return FASTEST_SPELL;
-      }
-      if (player.spellCards.length === QUICK_SPELL_INDEX) {
-        return QUICK_SPELL;
-      }
-      return player.spellCards.reduce((acc, cur): number => acc + cur.initiative, 0);
-    });
-    return this.players
-      .map((player: Player, index: number): [Player, number] => (
-        [player, orderSpells[index]]
-      ))
-      .sort((a, b) => b[1] - a[1])
-      .map((current: [Player, number]): Player => current[0]);
+    // const orderSpells = this.players.map((player) => {
+    //   // не забыть обработать когда меньше трех карт с 0 инициативой через кубик
+    //   if (player.spellCards.length === FASTEST_SPELL_INDEX) {
+    //     return FASTEST_SPELL;
+    //   }
+    //   if (player.spellCards.length === QUICK_SPELL_INDEX) {
+    //     return QUICK_SPELL;
+    //   }
+    //   return player.spellCards.reduce((acc, cur): number => acc + cur.initiative, 0);
+    // });
+    return this.players.sort((a, b) => a.spell.initiative - b.spell.initiative);
+    // .map((player: Player, index: number): [Player, number] => (
+    //   [player, orderSpells[index]]
+    // ))
+    // .sort((a, b) => b[1] - a[1])
+    // .map((current: [Player, number]): Player => current[0]);
   }
 
   public castSpells(): void {
@@ -57,7 +57,7 @@ export class CastingSpells {
 
     queue.forEach((player) => {
       // с фронтенда карты приходят в нужном порядке [source, quality, action]
-      const cards: Array<ICard> = player.spellCards;
+      const cards: Array<ICard> = [...player.spell];
       const positionPlayer: number = this.players.findIndex((current) => player === current);
       cards.forEach((currentCard: ICard) => {
         console.log('name spell', currentCard.id);
@@ -88,7 +88,7 @@ export class CastingSpells {
 
     const target = this.players[targetIndex];
 
-    const amountDice = player.spellCards
+    const amountDice = [...player.spell]
       .reduce((acc:number, card: ICard):number => (acc + card.magicSign === cardCurrent.magicSign ? 1 : 0), 0);
     const throwResult = rollDice(amountDice);
 
@@ -114,7 +114,7 @@ export class CastingSpells {
     }
     const target = this.players[targetIndex];
 
-    const amountDice = player.spellCards
+    const amountDice = [...player.spell]
       .reduce((acc:number, card: ICard):number => (acc + card.magicSign === cardCurrent.magicSign ? 1 : 0), 0);
     const throwResult = rollDice(amountDice);
 
@@ -134,7 +134,7 @@ export class CastingSpells {
   private useFountainYouthCard = (positionPlayer: number, cardCurrent: ICard) => {
     const player = this.players[positionPlayer];
 
-    const amountDice = player.spellCards
+    const amountDice = [...player.spell]
       .reduce((acc:number, card: ICard):number => (acc + card.magicSign === cardCurrent.magicSign ? 1 : 0), 0);
 
     const throwResult = rollDice(amountDice);

--- a/src/server/player/index.ts
+++ b/src/server/player/index.ts
@@ -1,1 +1,2 @@
 export { Player } from './player';
+export { PlayerSpell } from './player-spell';

--- a/src/server/player/player-spell.ts
+++ b/src/server/player/player-spell.ts
@@ -1,0 +1,32 @@
+import { ICard, CardTypes } from '../../common';
+
+const FASTEST_SPELL = 200;
+const QUICK_SPELL = 100;
+
+export class PlayerSpell {
+  private readonly cards = new Map<CardTypes, ICard>();
+
+  private spellSpeed = 0;
+
+  constructor(cards: Array<ICard>) {
+    // здесь при попытке добавить в заклинание карты того типа, который там уже есть - лишние карты просто игнорируются
+    cards.forEach((card) => {
+      if (!this.cards.has(card.type)) this.cards.set(card.type, card);
+    });
+
+    // считаем инициативу заклинания
+    const cardsCount = [...this.cards.keys()].length;
+    if (cardsCount === 1) this.spellSpeed += FASTEST_SPELL;
+    if (cardsCount === 2) this.spellSpeed += QUICK_SPELL;
+    this.spellSpeed += this.cards.get(CardTypes.action)?.initiative || 0;
+  }
+
+  get initiative(): number { return this.spellSpeed; }
+
+  // это итератор. благодаря ему можно перебрать PlayerSpell как массив или использовать спред
+  * [Symbol.iterator](): Generator<ICard> {
+    if (this.cards.has(CardTypes.source)) yield this.cards.get(CardTypes.source);
+    if (this.cards.has(CardTypes.quality)) yield this.cards.get(CardTypes.quality);
+    if (this.cards.has(CardTypes.action)) yield this.cards.get(CardTypes.quality);
+  }
+}

--- a/src/server/player/player.ts
+++ b/src/server/player/player.ts
@@ -1,11 +1,12 @@
 import { ICard } from '../../common';
+import { PlayerSpell } from './player-spell';
 
 const STARTING_HEALTH = 20;
 
 export class Player {
   private handCardsValue: Array<ICard> = [];
 
-  private spellCardsValue: Array<ICard> = [];
+  private currentSpell: PlayerSpell;
 
   private callback: { [name: string]: () => void } = {};
 
@@ -27,20 +28,19 @@ export class Player {
     this.handCardsValue = this.handCardsValue.filter((cardCurrent: ICard) => !cards.includes(cardCurrent));
 
     // кладем в активное заклинание
-    this.spellCardsValue = [...cards];
+    this.currentSpell = new PlayerSpell(cards);
 
     this.callback.cardSelectionHandler();
   }
 
-  public get spellCards(): Array<ICard> {
-    return this.spellCardsValue;
+  public get spell(): PlayerSpell {
+    return this.currentSpell;
   }
 
   public transferSpellCards(): Array<ICard> {
     this.isSpellReady = false;
     // передавая закл в отработку чистим слот
-    const result: Array<ICard> = [...this.spellCardsValue];
-    this.spellCardsValue = [];
+    const result: Array<ICard> = [...this.currentSpell];
     return result;
   }
 


### PR DESCRIPTION
Я вынес логику расчёта инициативы и проверки типов карт в отдельную сущность "заклинание". Её можно будет дорабатывать по мере усложнения логики. Пока это делал обнаружил ошибку в твоей логике расчёта инициативы - если у игрока одна карта он получает автоматом инициативу 200, но по правилам игры если у двух игроков будет по одной карте с типом действия, первым ходит тот игрок, у которого на карте действия выше инициатива. Моё предложение уже учитывает это при расчёте инициативы, остаётся только бросок кубика реализовать, но как и предлагал - считаю это лучше сделать отдельным методом у плеера и вызывать уже в твоём классе в функции расчёта порядка чтения заклинаний. Пока там осталась только сортировка, весь код который упростился/или был вынесен в отдельную сущность я закомментировал, удалять не стал. Посмотри, оцени, лучше такое решение какой-то функции или хуже. Как по мне - оно более удобное и прозрачное для понимания.

upd// обрати внимание, этот пулл реквест в твою ветку, не в девелоп)