### PR TITLE
config: fix assets paths

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -10,9 +10,10 @@ module.exports = {
     app: './index.ts'
   },
   output: {
-    filename: 'js/[name].[contenthash].js',
+    filename: '[name].[contenthash].js',
     path: paths.build_dir,
     publicPath: '/',
+    assetModuleFilename: 'assets/[hash][ext]',
   },
   module: {
     rules: [
@@ -69,7 +70,7 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: 'styles/[name].[contenthash].css',
+      filename: '[name].[contenthash].css',
     }),
     new HtmlWebpackPlugin({
       template: './index.html'
@@ -87,4 +88,7 @@ module.exports = {
   resolve: {
     extensions: [ '.ts', '.js' ],
   },
+  experiments: {
+    asset: true
+  }
 };

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -8,6 +8,7 @@ module.exports = merge(common, {
   devServer: {
     historyApiFallback: true,
     contentBase: paths.public_dir,
+    contentBasePublicPath: '/assets',
     open: true,
     compress: true,
     hot: true,


### PR DESCRIPTION
Исправлена проблема с загрузкой изображений в css

сейчас, все картинки/иконки/шрифты, которые вставляются в css стилях (например через background-image: url() должны помещаться в папку src/client/assets

т.к. все стили компонентов импортятся в главном файле стилей, то путь к папке assets указывается относительно этого файла, то есть ../assets/тут_имя_вашего_файла