### PR TITLE
Start AI opponents implementation

### DIFF
--- a/src/common/connection/base-connection.ts
+++ b/src/common/connection/base-connection.ts
@@ -1,13 +1,8 @@
 import { ICallbackHandler } from '../interfaces';
 import { IHubResponse } from '../interfaces/DTO/hub-response';
+import { ISocket } from './soket-iterface';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-interface ISocket {
-  id: string,
-  on: ICallbackHandler,
-  emit: ICallbackHandler,
-}
 
 export abstract class BaseConnection<TRequest, TEvent> {
   constructor(protected readonly socket: ISocket) { }

--- a/src/common/connection/index.ts
+++ b/src/common/connection/index.ts
@@ -1,3 +1,4 @@
 export * from './connection-constants';
 export { BaseConnection } from './base-connection';
 export { HubResponse } from './response-helpers';
+export { ISocket } from './soket-iterface';

--- a/src/common/connection/soket-iterface.ts
+++ b/src/common/connection/soket-iterface.ts
@@ -1,0 +1,7 @@
+import { ICallbackHandler } from '../interfaces';
+
+export interface ISocket {
+  id: string,
+  on: ICallbackHandler,
+  emit: ICallbackHandler,
+}

--- a/src/common/enums/hub-events.ts
+++ b/src/common/enums/hub-events.ts
@@ -4,6 +4,7 @@ export enum HubEventsServer {
   StartGame = 'start-game',
   AddPlayer = 'add-player',
   SelectSpell = 'select-spell',
+  AddBot = 'add-ai-player',
 }
 
 export enum HubEventsClient {
@@ -15,4 +16,5 @@ export enum HubEventsClient {
   DiceRoll = 'dice-roll',
   UpdateHealath = 'update-haalth',
   SpellSelected = 'spell-selected',
+  SelectTarget = 'select-target',
 }

--- a/src/common/interfaces/DTO/index.ts
+++ b/src/common/interfaces/DTO/index.ts
@@ -3,3 +3,4 @@ export { ICreatePlayerRequest } from './create-player-request';
 export { IHealthUpdate } from './update-heath-message';
 export { ISpellSelected } from './spell-selected-message';
 export { IDiceRoll } from './roll-dice-message';
+export { ISelectTarget } from './select-target-message';

--- a/src/common/interfaces/DTO/select-target-message.ts
+++ b/src/common/interfaces/DTO/select-target-message.ts
@@ -1,0 +1,4 @@
+export interface ISelectTarget {
+  numberOfTargets: number,
+  targets: Array<string>,
+}

--- a/src/server/bot/bot-connection.ts
+++ b/src/server/bot/bot-connection.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  HubEventsServer,
+  HubEventsClient,
+  IHubResponse,
+  ICard,
+  delay,
+  getRandomInteger,
+  ICallbackHandler,
+  START_HEALTH,
+  IHealthUpdate,
+  // ISelectTarget,
+} from '../../common';
+import { ClientConnection } from '../connection';
+
+const MIN_BOT_DELAY = 100;
+const MAX_BOT_DELAY = 1000;
+
+type EventHandler = (...args: any[]) => any;
+
+export class SimpleBotConnection extends ClientConnection {
+  // bot state
+  private handCards: Array<ICard> = [];
+
+  private health = START_HEALTH;
+
+  private readonly listeners: Map<HubEventsServer, Set<ICallbackHandler>> = new Map();
+
+  private readonly handlers: Map<HubEventsClient, EventHandler> = new Map();
+
+  constructor(gameId: string) {
+    super({
+      id: `bot_${(Math.random() * 1000).toFixed()}`,
+      on: () => { },
+      emit: () => { },
+    });
+    this.setGameId(gameId);
+
+    this.handlers
+      .set(HubEventsClient.DiceRoll, () => { })
+      .set(HubEventsClient.GetCards, (cards: Array<ICard>): void => {
+        this.handCards.push(...cards);
+        if (this.health > 0) this.selectSpell();
+      })
+      .set(HubEventsClient.UpdateHealath, (message: IHealthUpdate): void => {
+        this.health = message.currentHealth;
+      });
+    // .set(HubEventsClient.SelectTarget, (message: ISelectTarget): string[] => {
+    //   const randomResult: Array<string> = [];
+    //   while (randomResult.length < message.numberOfTargets && message.targets.length > 0) {
+    //     randomResult.push(...message.targets.splice(getRandomInteger(0, message.targets.length - 1), 1));
+    //   }
+    //   return randomResult;
+    // });
+  }
+
+  setGameId(gameId: string): void { this.gameId = gameId; }
+
+  dispatch<T>(command: HubEventsClient, ...args: any[]): Promise<T> {
+    const handler = this.handlers.get(command);
+    if (handler && typeof handler === 'function') {
+      const result = handler(...args);
+      return Promise.resolve(result as T);
+    }
+    return Promise.reject(Error('Unknown method'));
+  }
+
+  addEventListener<T>(
+    event: HubEventsServer,
+    handler: (...args: any[]) => IHubResponse<T> | Promise<IHubResponse<T>>,
+  ): void {
+    const handlerFunc = handler as ICallbackHandler;
+    if (!this.listeners.has(event)) {
+      const set = new Set<ICallbackHandler>();
+      this.listeners.set(event, set);
+    }
+    const eventListeners = this.listeners.get(event);
+    eventListeners?.add(handlerFunc);
+  }
+
+  removeListeners(event: HubEventsServer): void {
+    this.listeners.delete(event);
+  }
+
+  private async selectSpell(): Promise<void> {
+    // this delay simulate user thinking time
+    await delay(getRandomInteger(MIN_BOT_DELAY, MAX_BOT_DELAY));
+
+    // TODO: write spell selection logic here
+    // for example - select all cards with different magic signs
+    const selectedCards: Array<ICard> = this.handCards.reduce((acc, card) => {
+      if (acc.find((selectedCard) => selectedCard.magicSign !== card.magicSign)) {
+        return [...acc, card];
+      }
+      return acc;
+    }, [] as ICard[]);
+
+    // when cards selected, remove its from hand and dispatch callback whit selected cards id
+    this.handCards = this.handCards.filter((card) => !selectedCards.includes(card));
+    this.dispatchCallbacks(HubEventsServer.SelectSpell, selectedCards.map((card) => card.id));
+  }
+
+  private dispatchCallbacks<T>(event: HubEventsServer, ...args: T[]) {
+    const callback = this.listeners.get(event);
+    callback?.forEach((handler) => handler(...args));
+  }
+}

--- a/src/server/bot/index.ts
+++ b/src/server/bot/index.ts
@@ -1,0 +1,1 @@
+export { SimpleBotConnection } from './bot-connection';

--- a/src/server/connection/client-connection.ts
+++ b/src/server/connection/client-connection.ts
@@ -2,7 +2,7 @@ import { Socket } from 'socket.io';
 import { BaseConnection, HubEventsClient, HubEventsServer } from '../../common';
 
 export class ClientConnection extends BaseConnection<HubEventsClient, HubEventsServer> {
-  private gameId = '';
+  protected gameId = '';
 
   get currentGameId(): string { return this.gameId; }
 

--- a/src/server/player/player.ts
+++ b/src/server/player/player.ts
@@ -12,14 +12,19 @@ import {
   ICard,
   IHealthUpdate,
   ISpellSelected,
-  IDiceRoll, getRandomInteger,
+  IDiceRoll, getRandomInteger, ISelectTarget,
 } from '../../common';
 import { ClientConnection } from '../connection';
 import { PlayerEvents } from './player-events';
 import { PlayerSpell } from './player-spell';
 
-function race(task: Promise<void>): Promise<void> {
-  return Promise.race([delay(MAX_AWAIT_TIME), task]);
+function race<T>(task: Promise<T>, data?: T): Promise<T> {
+  return new Promise<T>((resolve) => {
+    delay(MAX_AWAIT_TIME).then(() => {
+      resolve(data as T);
+    });
+    task.then(resolve).catch(() => resolve(data as T));
+  });
 }
 
 export class Player {
@@ -69,12 +74,8 @@ export class Player {
   }
 
   async addCardsHand(cards: Array<ICard>): Promise<void> {
-    try {
-      this.handCardsValue = [...this.handCardsValue, ...cards];
-      await race(this.connection.dispatch(HubEventsClient.GetCards, cards));
-    } catch {
-      //
-    }
+    this.handCardsValue = [...this.handCardsValue, ...cards];
+    await race(this.connection.dispatch(HubEventsClient.GetCards, cards));
   }
 
   transferSpellCards(): Array<ICard> {
@@ -93,12 +94,8 @@ export class Player {
       currentHealth: this.hitPoints,
       isDamage: true,
     };
-    try {
-      this.dispatchCallbacks(PlayerEvents.UpdateHealths, message);
-      await race(this.connection.dispatch<void>(HubEventsClient.UpdateHealath, message));
-    } catch {
-      //
-    }
+    this.dispatchCallbacks(PlayerEvents.UpdateHealths, message);
+    await race(this.connection.dispatch<void>(HubEventsClient.UpdateHealath, message));
   }
 
   async takeHeal(heal: number): Promise<void> {
@@ -112,12 +109,8 @@ export class Player {
       currentHealth: this.hitPoints,
       isDamage: false,
     };
-    try {
-      this.dispatchCallbacks(PlayerEvents.UpdateHealths, message);
-      await race(this.connection.dispatch<void>(HubEventsClient.UpdateHealath, message));
-    } catch {
-      //
-    }
+    this.dispatchCallbacks(PlayerEvents.UpdateHealths, message);
+    await race(this.connection.dispatch<void>(HubEventsClient.UpdateHealath, message));
   }
 
   async makeDiceRoll(number: number, bonus = 0): Promise<number> {
@@ -128,13 +121,9 @@ export class Player {
       result += roll;
       rolls.push(roll);
     }
-    try {
-      const message: IDiceRoll = { playerId: this.id, rolls, bonus };
-      this.dispatchCallbacks(PlayerEvents.MakeDiceRoll, message);
-      await race(this.connection.dispatch<void>(HubEventsClient.DiceRoll, message));
-    } catch {
-      //
-    }
+    const message: IDiceRoll = { playerId: this.id, rolls, bonus };
+    this.dispatchCallbacks(PlayerEvents.MakeDiceRoll, message);
+    await race(this.connection.dispatch<void>(HubEventsClient.DiceRoll, message));
     return result + bonus;
   }
 
@@ -168,11 +157,13 @@ export class Player {
   // в методе нет this пока что
   // eslint-disable-next-line class-methods-use-this
   async selectTarget(targets: Array<string>, numberOfTargets = 1): Promise<Array<string>> {
-    try {
-      throw new Error('zaglushka');
-    } catch (e) {
-      const randomTarget = getRandomInteger(0, targets.length);
-      return [targets[randomTarget]];
+    const message: ISelectTarget = { targets, numberOfTargets };
+    const randomResult: Array<string> = [];
+    while (randomResult.length < numberOfTargets && targets.length > 0) {
+      randomResult.push(...targets.splice(getRandomInteger(0, targets.length - 1), 1));
     }
+    const selectTargetTask = this.connection.dispatch<string[]>(HubEventsClient.SelectTarget, message);
+    const result = await race(selectTargetTask, randomResult);
+    return result;
   }
 }

--- a/src/server/services/game-service.ts
+++ b/src/server/services/game-service.ts
@@ -10,11 +10,13 @@ import {
   IHealthUpdate,
   IDiceRoll,
   MAX_GAMES,
+  getRandomInteger,
 } from '../../common';
 import { ClientConnection, ConnectionService, ConnectionEvents } from '../connection';
 import { Player, PlayerEvents } from '../player';
 import { Game } from '../game/game';
 import { PlayerService } from './player-service';
+import { SimpleBotConnection } from '../bot/bot-connection';
 
 interface ICardRepository {
   getData: () => ICard[]
@@ -45,6 +47,9 @@ export class GameService {
     connection.addEventListener(HubEventsServer.StartGame, () => this.startGame(connection.currentGameId));
     connection.addEventListener(
       HubEventsServer.AddPlayer, (req: ICreatePlayerRequest) => this.createPlayer(req, connection),
+    );
+    connection.addEventListener(
+      HubEventsServer.AddBot, (heroId: string) => this.createBot(connection.currentGameId, heroId),
     );
   }
 
@@ -110,6 +115,36 @@ export class GameService {
       const playerPosition = game.players.length - 1;
       const playerInfo = GameService.getPlayerInfo(player, playerPosition);
       this.connectionService.dispatch(request.gameId, HubEventsClient.AddPlayer, playerInfo);
+      return HubResponse.Success<IPlayerInfo>(playerInfo);
+    } catch (err: unknown) {
+      return HubResponse.Error((<Error> err)?.message);
+    }
+  }
+
+  createBot(gameId: string, heroId: string): IHubResponse<IPlayerInfo | string> {
+    if (!this.games.has(gameId)) return GameService.notFound();
+
+    const game = <Game>(this.games.get(gameId));
+
+    const isHeroTaken = !(game.players.every((player) => player.hero !== heroId));
+    if (isHeroTaken) return HubResponse.Error('This hero is already taken');
+
+    const botNames: string[] = ['Toma', 'Max', 'Anna', 'Al'];
+    const playerNames: string[] = game.players.map((player) => player.name);
+    let botName: string;
+    do {
+      botName = botNames[getRandomInteger(0, botNames.length - 1)];
+    } while (playerNames.includes(botName));
+
+    const botConnection = new SimpleBotConnection(gameId);
+    const player = new Player(botConnection, botConnection.id, `[bot] ${botName}`, heroId);
+
+    try {
+      game.addPlayer(player);
+      this.addPlayerListeners(player, gameId);
+      const playerPosition = game.players.length - 1;
+      const playerInfo = GameService.getPlayerInfo(player, playerPosition);
+      this.connectionService.dispatch(gameId, HubEventsClient.AddPlayer, playerInfo);
       return HubResponse.Success<IPlayerInfo>(playerInfo);
     } catch (err: unknown) {
       return HubResponse.Error((<Error> err)?.message);


### PR DESCRIPTION
добавлена возможность добавлять в игру бота
бот - это по сути кастомный коннекшн, который передаётся в класс Player и обрабатывает диспатчи вместо юзера... 
вся логика бота по сути - выбирать карты для заклинания из доступных. Сейчас реализован начальный функционал - выбираются все карты разных типов по порядку, для теста должно хватить такой логики.
добавлен коллбек на клиенте и диспатч на сервере для выбора цели заклинания юзером. Если юзер не отвечает или отвечает слишком долго - цели выбираются рандомно.
для всего этого функционала пришлось немного по-рефакторить...

опять навалил всё в один PR...
интересно оно вообще будет работать? жду не дождусь возможности потестить)